### PR TITLE
This commit creates panning functionality. When a ticker row is click…

### DIFF
--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -4,6 +4,17 @@ import GoogleMapReact from 'google-map-react'
 import { blueWater, unsaturatedBrowns, greenTheme, dark, midnight, autumnWorld } from '../Assets/mapTheme'
 import { Markers } from './'
 import { setMapStatus } from '../store'
+import {setPanning} from '../store/panCoords'
+
+
+const defaultCenter = { lat: 40.70, lng: -74.00 }
+
+const style = {
+  top: 0,
+  bottom: 0,
+  height: '100vh',
+  width: '100vw'
+}
 
 class Map extends Component {
   constructor(props) {
@@ -52,29 +63,25 @@ class Map extends Component {
       this.setState({ center: { lat, lng } })
     }
 
-    //UPDATE MAP LOGIC
+    //UPDATE MAP THEME
     const turn = Math.floor(this.props.establishments.length/10)%7
     console.log('Today\'s map is ', turn)
     const theme = [ blueWater, greenTheme, greenTheme, autumnWorld, unsaturatedBrowns, dark, midnight][turn]
     if(this.props.mapStatus!==theme) this.props.setMapStatus(theme)
-    //EXPERIMENTAL - MAP PANNING
-    // if(this.map) console.log('MAP ', this.map)
-    // if(this.map && this.map.map_) {
-    //   console.log('HEY ', this.map.map_)
-    //   this.map.map_.panTo({lat:40.7794366, lng:-73.96324400000003})
-    // }
-    // this.updateMapTheme()
-    const style = {
-      top: 0,
-      bottom: 0,
-      height: '100vh',
-      width: '100vw'
+    
+
+    if(this.map && this.map.map_){
+        console.log('Hey the api has loaded? ', this.map.map_)
+        console.log('How are pancoords doing ', this.state.panCoords)
+        if(this.props.panCoords.length>1){ this.map.map_.panTo({lat:this.props.panCoords[0], lng: this.props.panCoords[1]}) ; this.props.setPanning([]) }
     }
+
+
     return (
       <div id="map" style={style}>
         <GoogleMapReact
           bootstrapURLKeys={this.state.bootstrapURLKeys}
-          defaultCenter={{ lat: 40.70, lng: -74.00 }}
+          defaultCenter={ defaultCenter }
           center={this.state.center}
           defaultZoom={this.state.zoom}
           heatmapLibrary={true}
@@ -135,11 +142,13 @@ class Map extends Component {
     establishments: state.establishments,
     trackLocation: state.trackLocation,
     mapStatus: state.mapStatus,
-    user: state.user
+    user: state.user,
+    panCoords: state.panCoords
   })
 
   const mapDispatch = dispatch => ({
-    setMapStatus: theme => dispatch(setMapStatus(theme))
+    setMapStatus: theme => dispatch(setMapStatus(theme)),
+    setPanning: coords => dispatch(setPanning(coords))
   })
 
   export default connect(mapState, mapDispatch)(Map)

--- a/src/components/Ticker.js
+++ b/src/components/Ticker.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { CSSTransitionGroup } from 'react-transition-group' 
+import { setPanning } from '../store/panCoords'
 
 class Ticker extends Component{
     constructor(props){
@@ -32,7 +33,7 @@ class Ticker extends Component{
                                 .filter(checkin => Date.now() - Date.parse(checkin.createdAt) < 1800000)
                                 .reverse()
                                 .map(check => 
-                                    <div className="tickerTape" key={check.id}>
+                                    <div className="tickerTape" key={check.id} onClick={()=>{console.log(check.establishment);this.props.setPanning([Number(check.establishment.latitude), Number(check.establishment.longitude)])}}>
                                         {`${check.user.username} just checked into ${check.establishment.name}!`}
                                     </div>
                                 )
@@ -45,5 +46,6 @@ class Ticker extends Component{
 }
 
 const mapProps = ({ checkins }) => ({ checkins })
+const mapDispatch = dispatch => ({setPanning: coords => {dispatch(setPanning(coords))}})
 
-export default connect(mapProps)(Ticker)
+export default connect(mapProps, mapDispatch)(Ticker)

--- a/src/index.js
+++ b/src/index.js
@@ -8,8 +8,6 @@ import store from './store'
 import App from './App';
 import registerServiceWorker from './registerServiceWorker'
 
-// establishes socket connection
-import './sockets'
 
 ReactDOM.render(
   <Provider store={store}>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -12,8 +12,9 @@ import trackLocation from './trackLocation'
 import verify from './gameplay'
 import mapStatus from './mapStatus'
 import shields from './shields'
+import panCoords from './panCoords'
 
-const reducer = combineReducers({ user, users, markers, checkins, establishments, kingdoms, trackLocation, verify, mapStatus, shields })
+const reducer = combineReducers({ user, users, markers, checkins, establishments, kingdoms, trackLocation, verify, mapStatus, shields, panCoords })
 
 const middleware = composeWithDevTools(applyMiddleware(
     thunkMiddleware,

--- a/src/store/panCoords.js
+++ b/src/store/panCoords.js
@@ -1,0 +1,11 @@
+const SET_PAN_COORDS = 'SET_PAN_COORDS'
+
+export const setPanning = arrayOfTwoCoords => ({type: SET_PAN_COORDS, coords: arrayOfTwoCoords})
+
+export default function (coords = [], action){
+
+    switch(action.type){
+        case SET_PAN_COORDS: return action.coords
+        default: return coords
+    }
+}


### PR DESCRIPTION
…ed, the map will pan to the location described, so the user may see where the checkin occured, and help understand network events from other users.

This works by sending coordinates to pan-to up into the redux store. The map has a subscription to these coordinates and will re-render when they are updated, panning and then erasing them in the store. This triggers an immediate second re-render: I'm wondering if there is a workaround to this.